### PR TITLE
Use akka 2.6 and bump libraries.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,56 +23,63 @@ lazy val library =
   new {
 
     object Version {
-      val scalaCheck = "1.14.3"
-      val scalaTest  = "3.1.0"
-      val jackson    = "2.10.1"
-      val akka       = "2.6.1"
+      val scalaCheck            = "1.14.3"
+      val scalaTest             = "3.1.0"
+      val jackson               = "2.10.1"
+      val akka                  = "2.6.1"
+      val fasterxml             = "3.2.0"
+      val kcl                   = "1.13.1"
+      val kpl                   = "0.14.0"
+      val typesafeConfig        = "1.3.3"
+      val logbackClassic        = "1.2.3"
+      val scalatestMockito      = "3.1.0.0"
+      val scalatestScalaCheck   = "3.1.0.1"
+      val scalaLogging          = "3.9.2"
+      val mockito               = "2.16.0"
+      val scalaCollectionCompat = "2.1.1"
     }
 
     val jackson = Seq(
       //We need jackson versions to be consistent, KCL&KPL pull in slightly older versions which often get evicted
       //See: https://github.com/aws/aws-sdk-java/issues/999
-      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % Version.jackson % Compile,
-      "com.fasterxml.jackson.core"       % "jackson-databind"        % Version.jackson % Compile,
-      "com.fasterxml.jackson.core"       % "jackson-core"            % Version.jackson % Compile,
-      "com.fasterxml.jackson.core"       % "jackson-annotations"     % Version.jackson % Compile,
-      "com.fasterxml.uuid"               % "java-uuid-generator"     % "3.2.0"         % Compile
+      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % Version.jackson   % Compile,
+      "com.fasterxml.jackson.core"       % "jackson-databind"        % Version.jackson   % Compile,
+      "com.fasterxml.jackson.core"       % "jackson-core"            % Version.jackson   % Compile,
+      "com.fasterxml.jackson.core"       % "jackson-annotations"     % Version.jackson   % Compile,
+      "com.fasterxml.uuid"               % "java-uuid-generator"     % Version.fasterxml % Compile
     )
 
     val amazon = Seq(
-      // TODO: Upgrade this to 1.9.x when this issue is resolved and exposed in localstack:
-      // https://github.com/mhart/kinesalite/issues/59
-      // 1.9.3 breaks KinesisSourceGraphStageIntegrationSpec and ConsumerProcessingManagerIntegrationSpec
-      "com.amazonaws" % "amazon-kinesis-client" % "1.13.1" % Compile
+      "com.amazonaws" % "amazon-kinesis-client" % Version.kcl % Compile
       excludeAll (ExclusionRule(organization = "com.fasterxml.jackson.core"),
       ExclusionRule(organization = "com.fasterxml.jackson.dataformat")),
-      "com.amazonaws" % "amazon-kinesis-producer" % "0.14.0" % Compile
+      "com.amazonaws" % "amazon-kinesis-producer" % Version.kpl % Compile
       excludeAll (ExclusionRule(organization = "com.fasterxml.jackson.core"),
       ExclusionRule(organization = "com.fasterxml.jackson.dataformat"))
     )
 
     val lightbend = Seq(
-      "com.typesafe"               % "config"         % "1.3.3"      % Compile,
-      "com.typesafe.akka"          %% "akka-actor"    % Version.akka % Compile,
-      "com.typesafe.akka"          %% "akka-stream"   % Version.akka % Compile,
-      "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"      % Compile
+      "com.typesafe"               % "config"         % Version.typesafeConfig % Compile,
+      "com.typesafe.akka"          %% "akka-actor"    % Version.akka           % Compile,
+      "com.typesafe.akka"          %% "akka-stream"   % Version.akka           % Compile,
+      "com.typesafe.scala-logging" %% "scala-logging" % Version.scalaLogging   % Compile
     )
 
     val logback = Seq(
-      "ch.qos.logback" % "logback-classic" % "1.2.3" % Compile
+      "ch.qos.logback" % "logback-classic" % Version.logbackClassic % Compile
     )
 
     val testing = Seq(
-      "org.scalatest"     %% "scalatest"       % Version.scalaTest  % "it,test",
-      "org.scalatestplus" %% "mockito-1-10"    % "3.1.0.0"          % "it,test",
-      "org.scalatestplus" %% "scalacheck-1-14" % "3.1.0.1"          % "it,test",
-      "org.scalacheck"    %% "scalacheck"      % Version.scalaCheck % "it,test",
-      "com.typesafe.akka" %% "akka-testkit"    % Version.akka       % "it,test",
-      "org.mockito"       % "mockito-core"     % "2.16.0"           % "it,test"
+      "org.scalatest"     %% "scalatest"       % Version.scalaTest           % "it,test",
+      "org.scalatestplus" %% "mockito-1-10"    % Version.scalatestMockito    % "it,test",
+      "org.scalatestplus" %% "scalacheck-1-14" % Version.scalatestScalaCheck % "it,test",
+      "org.scalacheck"    %% "scalacheck"      % Version.scalaCheck          % "it,test",
+      "com.typesafe.akka" %% "akka-testkit"    % Version.akka                % "it,test",
+      "org.mockito"       % "mockito-core"     % Version.mockito             % "it,test"
     )
 
     val compat = Seq(
-      "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.1"
+      "org.scala-lang.modules" %% "scala-collection-compat" % Version.scalaCollectionCompat
     )
   }
 
@@ -87,7 +94,7 @@ versioningSettings
 
 lazy val commonSettings =
   Seq(
-    //version := "0.1.14", //automatically calculated by sbt-git
+    version := "0.6.12", //automatically calculated by sbt-git
     //scalaVersion := "2.11.11", // taken from .travis.yml via sbt-travisci
     organization := "com.weightwatchers",
     mappings.in(Compile, packageBin) += baseDirectory.in(ThisBuild).value / "LICENSE" -> "LICENSE",
@@ -182,8 +189,6 @@ lazy val versioningSettings =
       case _                           => None
     }
   )
-
-import sbt.Keys.parallelExecution
 
 lazy val headerSettings =
   Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -23,10 +23,10 @@ lazy val library =
   new {
 
     object Version {
-      val scalaCheck = "1.14.0"
-      val scalaTest  = "3.0.8"
-      val jackson    = "2.9.8"
-      val akka       = "2.5.23"
+      val scalaCheck = "1.14.3"
+      val scalaTest  = "3.1.0"
+      val jackson    = "2.10.1"
+      val akka       = "2.6.1"
     }
 
     val jackson = Seq(
@@ -36,17 +36,17 @@ lazy val library =
       "com.fasterxml.jackson.core"       % "jackson-databind"        % Version.jackson % Compile,
       "com.fasterxml.jackson.core"       % "jackson-core"            % Version.jackson % Compile,
       "com.fasterxml.jackson.core"       % "jackson-annotations"     % Version.jackson % Compile,
-      "com.fasterxml.uuid"               % "java-uuid-generator"     % "3.1.5"         % Compile
+      "com.fasterxml.uuid"               % "java-uuid-generator"     % "3.2.0"         % Compile
     )
 
     val amazon = Seq(
       // TODO: Upgrade this to 1.9.x when this issue is resolved and exposed in localstack:
       // https://github.com/mhart/kinesalite/issues/59
       // 1.9.3 breaks KinesisSourceGraphStageIntegrationSpec and ConsumerProcessingManagerIntegrationSpec
-      "com.amazonaws" % "amazon-kinesis-client" % "1.11.1" % Compile
+      "com.amazonaws" % "amazon-kinesis-client" % "1.13.1" % Compile
       excludeAll (ExclusionRule(organization = "com.fasterxml.jackson.core"),
       ExclusionRule(organization = "com.fasterxml.jackson.dataformat")),
-      "com.amazonaws" % "amazon-kinesis-producer" % "0.12.11" % Compile
+      "com.amazonaws" % "amazon-kinesis-producer" % "0.14.0" % Compile
       excludeAll (ExclusionRule(organization = "com.fasterxml.jackson.core"),
       ExclusionRule(organization = "com.fasterxml.jackson.dataformat"))
     )
@@ -63,10 +63,12 @@ lazy val library =
     )
 
     val testing = Seq(
-      "org.scalatest"     %% "scalatest"    % Version.scalaTest  % "it,test",
-      "org.scalacheck"    %% "scalacheck"   % Version.scalaCheck % "it,test",
-      "com.typesafe.akka" %% "akka-testkit" % Version.akka       % "it,test",
-      "org.mockito"       % "mockito-core"  % "2.16.0"           % "it,test"
+      "org.scalatest"     %% "scalatest"       % Version.scalaTest  % "it,test",
+      "org.scalatestplus" %% "mockito-1-10"    % "3.1.0.0"          % "it,test",
+      "org.scalatestplus" %% "scalacheck-1-14" % "3.1.0.1"          % "it,test",
+      "org.scalacheck"    %% "scalacheck"      % Version.scalaCheck % "it,test",
+      "com.typesafe.akka" %% "akka-testkit"    % Version.akka       % "it,test",
+      "org.mockito"       % "mockito-core"     % "2.16.0"           % "it,test"
     )
 
     val compat = Seq(
@@ -136,7 +138,7 @@ lazy val commonSettings =
     ),
     scalacOptions in (Compile, console) ~= (_.filterNot(
       Set(
-        "-Ywarn-unused:imports",
+        // "-Ywarn-unused:imports",
         "-Xfatal-warnings"
       )
     )),

--- a/build.sbt
+++ b/build.sbt
@@ -94,7 +94,7 @@ versioningSettings
 
 lazy val commonSettings =
   Seq(
-    version := "0.6.12", //automatically calculated by sbt-git
+    // version := "0.6.12", //automatically calculated by sbt-git
     //scalaVersion := "2.11.11", // taken from .travis.yml via sbt-travisci
     organization := "com.weightwatchers",
     mappings.in(Compile, packageBin) += baseDirectory.in(ThisBuild).value / "LICENSE" -> "LICENSE",
@@ -145,7 +145,6 @@ lazy val commonSettings =
     ),
     scalacOptions in (Compile, console) ~= (_.filterNot(
       Set(
-        // "-Ywarn-unused:imports",
         "-Xfatal-warnings"
       )
     )),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.8
+sbt.version = 1.3.5

--- a/src/it/scala/com/weightwatchers/reactive/kinesis/KinesisProducerIntegrationSpec.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/KinesisProducerIntegrationSpec.scala
@@ -16,35 +16,15 @@
 
 package com.weightwatchers.reactive.kinesis
 
-import java.io.File
-
-import com.amazonaws.services.kinesis.producer.{KinesisProducer => AWSKinesisProducer}
-import com.typesafe.config.ConfigFactory
-import com.weightwatchers.reactive.kinesis.common.{
-  KinesisSuite,
-  KinesisTestConsumer,
-  TestCredentials
-}
-import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer.ConsumerConf
+import com.weightwatchers.reactive.kinesis.common.{IntegrationTest, KinesisSuite}
 import com.weightwatchers.reactive.kinesis.models.ProducerEvent
-import com.weightwatchers.reactive.kinesis.producer.{KinesisProducer, ProducerConf}
-import org.scalatest.concurrent.Eventually
-import org.scalatestplus.mockito.MockitoSugar
+import com.weightwatchers.reactive.kinesis.producer.KinesisProducer
 import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
-
-import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.Random
 
 //scalastyle:off magic.number
-class KinesisProducerIntegrationSpec
-    extends FreeSpec
-    with Matchers
-    with MockitoSugar
-    with BeforeAndAfterAll
-    with Eventually
-    with KinesisSuite {
+class KinesisProducerIntegrationSpec extends IntegrationTest with KinesisSuite {
 
   implicit val ece = scala.concurrent.ExecutionContext.global
 

--- a/src/it/scala/com/weightwatchers/reactive/kinesis/SimpleKinesisConsumer.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/SimpleKinesisConsumer.scala
@@ -16,6 +16,7 @@ import com.weightwatchers.reactive.kinesis.models.CompoundSequenceNumber
 import org.joda.time.{DateTime, DateTimeZone, Period}
 
 import scala.collection.mutable.ListBuffer
+import scala.collection.Seq
 import com.weightwatchers.eventing.system
 
 object RunSimpleConsumer extends App {

--- a/src/it/scala/com/weightwatchers/reactive/kinesis/common/AkkaUnitTestLike.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/common/AkkaUnitTestLike.scala
@@ -1,13 +1,27 @@
 package com.weightwatchers.reactive.kinesis.common
 
 import akka.actor.{ActorSystem, Scheduler}
-import akka.stream.{ActorMaterializer, Materializer}
 import akka.testkit.TestKitBase
 import com.typesafe.config.{Config, ConfigFactory}
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Suite}
-
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.freespec.AnyFreeSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, GivenWhenThen, Suite}
+import org.scalatestplus.mockito.MockitoSugar
 import scala.concurrent.ExecutionContextExecutor
+
+
+/**
+  * Base trait for all integration tests.
+  */
+trait IntegrationTest
+  extends AnyFreeSpecLike
+    with Matchers
+    with MockitoSugar
+    with GivenWhenThen
+    with ScalaFutures
+    with Eventually
+    with BeforeAndAfterAll
 
 /**
   * Use this test trait for akka based tests.
@@ -19,7 +33,6 @@ trait AkkaUnitTestLike extends TestKitBase with ScalaFutures with BeforeAndAfter
   implicit lazy val config: Config                = ConfigFactory.load("sample.conf")
   implicit lazy val system: ActorSystem           = ActorSystem(suiteName, config)
   implicit lazy val scheduler: Scheduler          = system.scheduler
-  implicit lazy val mat: Materializer             = ActorMaterializer()
   implicit lazy val ctx: ExecutionContextExecutor = system.dispatcher
 
   abstract override def afterAll(): Unit = {

--- a/src/it/scala/com/weightwatchers/reactive/kinesis/common/KinesisSuite.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/common/KinesisSuite.scala
@@ -228,7 +228,8 @@ trait KinesisSuite
   private def createLeaseTable(applicationName: String): Unit = {
     val manager = new LeaseManager[KinesisClientLease](s"$applicationName-$TestStreamName",
                                                        dynamoClient,
-                                                       new KinesisClientLeaseSerializer(),BillingMode.PROVISIONED)
+                                                       new KinesisClientLeaseSerializer(),
+                                                       BillingMode.PROVISIONED)
     manager.createLeaseTableIfNotExists(1L, 1L)
     while (!manager.leaseTableExists()) Thread.sleep(100)
   }

--- a/src/it/scala/com/weightwatchers/reactive/kinesis/common/KinesisSuite.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/common/KinesisSuite.scala
@@ -2,14 +2,10 @@ package com.weightwatchers.reactive.kinesis.common
 
 import java.io.File
 import java.nio.ByteBuffer
-
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
+import com.amazonaws.services.dynamodbv2.model.BillingMode
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBClientBuilder}
-import com.amazonaws.services.kinesis.leases.impl.{
-  KinesisClientLease,
-  KinesisClientLeaseSerializer,
-  LeaseManager
-}
+import com.amazonaws.services.kinesis.leases.impl.{KinesisClientLease, KinesisClientLeaseSerializer, LeaseManager}
 import com.amazonaws.services.kinesis.model.PutRecordRequest
 import com.amazonaws.services.kinesis.{AmazonKinesisAsync, AmazonKinesisAsyncClientBuilder}
 import com.typesafe.config.{Config, ConfigFactory}
@@ -17,7 +13,6 @@ import com.typesafe.scalalogging.StrictLogging
 import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer.ConsumerConf
 import com.weightwatchers.reactive.kinesis.producer.ProducerConf
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, Suite}
-
 import scala.jdk.CollectionConverters._
 import scala.concurrent.duration._
 
@@ -233,7 +228,7 @@ trait KinesisSuite
   private def createLeaseTable(applicationName: String): Unit = {
     val manager = new LeaseManager[KinesisClientLease](s"$applicationName-$TestStreamName",
                                                        dynamoClient,
-                                                       new KinesisClientLeaseSerializer())
+                                                       new KinesisClientLeaseSerializer(),BillingMode.PROVISIONED)
     manager.createLeaseTableIfNotExists(1L, 1L)
     while (!manager.leaseTableExists()) Thread.sleep(100)
   }
@@ -281,6 +276,8 @@ trait KinesisSuite
   }
 
   protected def createTestData(testDataCount: Int): Unit = {
+    import scala.jdk.CollectionConverters._
+
     kinesisClient
       .describeStream(TestStreamName)
       .getStreamDescription

--- a/src/it/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerProcessingManagerIntegrationSpec.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerProcessingManagerIntegrationSpec.scala
@@ -2,29 +2,18 @@ package com.weightwatchers.reactive.kinesis.consumer
 
 import akka.actor.{ActorRef, Props}
 import akka.testkit.TestProbe
-import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.{
-  IRecordProcessor,
-  IRecordProcessorFactory
-}
-import com.weightwatchers.reactive.kinesis.common.{
-  AkkaUnitTestLike,
-  KinesisConfiguration,
-  KinesisSuite
-}
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.{IRecordProcessor, IRecordProcessorFactory}
+import com.weightwatchers.reactive.kinesis.common.{AkkaUnitTestLike, IntegrationTest, KinesisConfiguration, KinesisSuite}
 import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer.ConsumerConf
-import org.scalatest.concurrent.Eventually
-import org.scalatest.{FreeSpec, Matchers}
-
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
 
 class ConsumerProcessingManagerIntegrationSpec
-    extends FreeSpec
+    extends IntegrationTest
     with KinesisSuite
     with KinesisConfiguration
     with AkkaUnitTestLike
-    with Matchers
-    with Eventually {
+ {
 
   override def TestStreamNrOfMessagesPerShard: Long    = 0
   override def TestStreamNumberOfShards: Long          = 2

--- a/src/it/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSinkGraphStageIntegrationSpec.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSinkGraphStageIntegrationSpec.scala
@@ -1,22 +1,16 @@
 package com.weightwatchers.reactive.kinesis.stream
 
 import akka.stream.scaladsl.Source
-import com.weightwatchers.reactive.kinesis.common.{
-  AkkaUnitTestLike,
-  KinesisConfiguration,
-  KinesisSuite
-}
+import com.weightwatchers.reactive.kinesis.common.{AkkaUnitTestLike, IntegrationTest, KinesisConfiguration, KinesisSuite}
 import com.weightwatchers.reactive.kinesis.models.ProducerEvent
-import org.scalatest.{FreeSpec, Matchers}
-
 import scala.concurrent.duration._
 
 class KinesisSinkGraphStageIntegrationSpec
-    extends FreeSpec
+    extends IntegrationTest
     with KinesisSuite
     with KinesisConfiguration
     with AkkaUnitTestLike
-    with Matchers {
+{
 
   "KinesisSinkGraph" - {
 

--- a/src/it/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSourceGraphStageIntegrationSpec.scala
+++ b/src/it/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSourceGraphStageIntegrationSpec.scala
@@ -1,21 +1,14 @@
 package com.weightwatchers.reactive.kinesis.stream
 
 import akka.stream.scaladsl.Sink
-import com.weightwatchers.reactive.kinesis.common.{
-  AkkaUnitTestLike,
-  KinesisConfiguration,
-  KinesisSuite
-}
-import org.scalatest._
-
+import com.weightwatchers.reactive.kinesis.common.{AkkaUnitTestLike, IntegrationTest, KinesisConfiguration, KinesisSuite}
 import scala.concurrent.duration._
 
 class KinesisSourceGraphStageIntegrationSpec
-    extends FreeSpec
+    extends IntegrationTest
     with KinesisSuite
     with KinesisConfiguration
-    with AkkaUnitTestLike
-    with Matchers {
+    with AkkaUnitTestLike {
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(60.seconds, 1.second)
 

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/CheckpointWorker.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/CheckpointWorker.scala
@@ -134,10 +134,10 @@ private[consumer] class CheckpointWorker(backOffTime: FiniteDuration,
     cancelTimers()
     // continually remind the ConsumerWorker we're ready!
     checkpointNotificationTimer = Some(
-      context.system.scheduler.schedule(notificationDelay,
-                                        notificationDelay,
-                                        context.parent,
-                                        ReadyToCheckpoint)(context.dispatcher)
+      context.system.scheduler.scheduleWithFixedDelay(notificationDelay,
+                                                      notificationDelay,
+                                                      context.parent,
+                                                      ReadyToCheckpoint)(context.dispatcher)
     )
 
     def readyState: Receive = LoggingReceive {

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerProcessingManager.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerProcessingManager.scala
@@ -38,10 +38,10 @@ import com.weightwatchers.reactive.kinesis.consumer.ConsumerWorker.{
 import com.weightwatchers.reactive.kinesis.models.{CompoundSequenceNumber, ConsumerEvent}
 import org.joda.time.{DateTime, DateTimeZone}
 
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.Try
-import scala.jdk.CollectionConverters._
 
 /**
   * Manages the processing of messages for a SPECIFIC SHARD.
@@ -100,7 +100,7 @@ private[consumer] class ConsumerProcessingManager(
       // Process records and perform all exception handling.
       val allRecordsProcessedFut: Future[ProcessingComplete] =
         (consumerWorker ? ProcessEvents(
-          processRecordsInput.getRecords.asScala.map(toConsumerEvent).toSeq,
+          processRecordsInput.getRecords.asScala.map(toConsumerEvent),
           processRecordsInput.getCheckpointer,
           kinesisShardId
         )).mapTo[ProcessingComplete]

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorker.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorker.scala
@@ -44,6 +44,7 @@ import com.weightwatchers.reactive.kinesis.consumer.ConsumerWorker._
 import com.weightwatchers.reactive.kinesis.models.{CompoundSequenceNumber, ConsumerEvent}
 import scala.language.postfixOps
 
+import scala.collection.Seq
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.util.Success
 
@@ -225,7 +226,7 @@ private[consumer] class ConsumerWorker(eventProcessor: ActorRef,
                                     None) {
 
     private val batchSequenceNumbers: collection.mutable.SortedSet[CompoundSequenceNumber] =
-      collection.mutable.SortedSet(expectedResponses.map(_.sequenceNumber): _*)(
+      collection.mutable.SortedSet.from(expectedResponses.map(_.sequenceNumber))(
         CompoundSequenceNumber.orderingBySeqAndSubSeq.reverse
       )
 

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/UnitTest.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/UnitTest.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 WeightWatchers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.weightwatchers.reactive.kinesis
+
+import akka.actor.{ActorSystem, Scheduler}
+import akka.testkit.TestKit
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.concurrent.{Eventually, PatienceConfiguration, ScalaFutures}
+import org.scalatest.{BeforeAndAfterAll, GivenWhenThen, Suite}
+import org.scalatest.freespec.AnyFreeSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Seconds, Span}
+import org.scalatestplus.mockito.MockitoSugar
+
+/**
+  * Base trait for all unit tests.
+  */
+trait UnitTest
+    extends AnyFreeSpecLike
+    with Matchers
+    with MockitoSugar
+    with GivenWhenThen
+    with ScalaFutures
+    with Eventually
+    with BeforeAndAfterAll
+
+trait AkkaTest extends BeforeAndAfterAll with PatienceConfiguration { this: Suite =>
+
+  protected implicit lazy val system: ActorSystem = ActorSystem(suiteName, akkaConfig)
+
+  protected implicit lazy val akkaScheduler: Scheduler = system.scheduler
+
+  protected def akkaConfig: Config = ConfigFactory.load()
+
+  override protected def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+
+  // Adjust the default patience configuration for all akka based tests
+  override implicit def patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = scaled(Span(2, Seconds)))
+}

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/CheckpointWorkerSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/CheckpointWorkerSpec.scala
@@ -16,28 +16,19 @@
 
 package com.weightwatchers.reactive.kinesis.consumer
 
-import akka.actor.{Actor, ActorRef, ActorSystem}
-import akka.testkit.{TestActorRef, TestDuration, TestKit, TestProbe}
+import akka.actor.{Actor, ActorRef}
+import akka.testkit.{TestActorRef, TestDuration, TestProbe}
 import com.amazonaws.services.kinesis.clientlibrary.exceptions.ThrottlingException
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer
 import com.typesafe.config.ConfigFactory
-import com.weightwatchers.reactive.kinesis.consumer.CheckpointWorker._
+import com.weightwatchers.reactive.kinesis.consumer.CheckpointWorker.{ReadyToCheckpoint, _}
 import com.weightwatchers.reactive.kinesis.models.CompoundSequenceNumber
-import com.weightwatchers.reactive.kinesis.consumer.CheckpointWorker.ReadyToCheckpoint
+import com.weightwatchers.reactive.kinesis.{AkkaTest, UnitTest}
 import org.mockito.Mockito
-import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, FreeSpecLike, Matchers}
-
-import scala.concurrent.Await
 import scala.concurrent.duration._
 
 //scalastyle:off magic.number
-class CheckpointWorkerSpec
-    extends TestKit(ActorSystem("checkpoint-worker-spec"))
-    with FreeSpecLike
-    with Matchers
-    with MockitoSugar
-    with BeforeAndAfterAll {
+class CheckpointWorkerSpec extends UnitTest with AkkaTest {
 
   val config = ConfigFactory.parseString("""
       |kinesis {
@@ -76,11 +67,6 @@ class CheckpointWorkerSpec
   val checkpointResultTimeout: FiniteDuration       = 2000.millis
   val checkpointNotificationTimeout: FiniteDuration = 1500.millis
   val checkpointBackoffTimeout: FiniteDuration      = parsedCheckpointerConf.backoff.dilated
-
-  override def afterAll(): Unit = {
-    system.terminate()
-    Await.result(system.whenTerminated, 5.seconds)
-  }
 
   "The CheckpointWorker" - {
 

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerConfSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerConfSpec.scala
@@ -16,30 +16,16 @@
 
 package com.weightwatchers.reactive.kinesis.consumer
 
-import java.io.File
-
-import akka.actor.ActorSystem
-import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer.ConsumerConf
-import org.scalatest._
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatestplus.mockito.MockitoSugar
+import com.weightwatchers.reactive.kinesis.{AkkaTest, UnitTest}
+import java.io.File
 import org.scalatest.time.{Millis, Seconds, Span}
-
 import scala.concurrent.duration.DurationInt
 
 //scalastyle:off magic.number
-class ConsumerConfSpec
-    extends TestKit(ActorSystem("consumer-conf-spec"))
-    with ImplicitSender
-    with FreeSpecLike
-    with Matchers
-    with MockitoSugar
-    with BeforeAndAfterAll
-    with GivenWhenThen
-    with ScalaFutures {
+class ConsumerConfSpec extends UnitTest with AkkaTest {
 
   val defaultKinesisConfig =
     ConfigFactory.parseFile(new File("src/main/resources/reference.conf")).getConfig("kinesis")
@@ -158,7 +144,7 @@ class ConsumerConfSpec
         |
         |         # Default: no timeout
         |         timeoutInSeconds = 10
-        |         
+        |
         |
         |         # The amount of milliseconds to wait before graceful shutdown forcefully terminates.
         |         # Default: 5000
@@ -176,41 +162,41 @@ class ConsumerConfSpec
         |         # max number of threads in the getRecords thread pool
         |         # Default: Optional value, default not set
         |         maxGetRecordsThreadPool = 1
-        |         
+        |
         |         #
         |         # Pre-fetching config
         |         #
-        |         
+        |
         |         # Pre-fetching will retrieve and queue additional records from Kinesis while the
         |         # application is processing existing records.
         |         # Pre-fetching can be enabled by setting dataFetchingStrategy to PREFETCH_CACHED. Once
-        |         # enabled an additional fetching thread will be started to retrieve records from Kinesis. 
+        |         # enabled an additional fetching thread will be started to retrieve records from Kinesis.
         |         # Retrieved records will be held in a queue until the application is ready to process them.
-        |         
+        |
         |         # Which data fetching strategy to use (DEFAULT, PREFETCH_CACHED)
         |         # Default: DEFAULT
         |         dataFetchingStrategy = DEFAULT
-        |         
+        |
         |         #
         |         # Pre-fetching supports the following configuration values:
         |         #
-        |         
+        |
         |         # The maximum number of process records input that can be queued
         |         # Default: 3
         |         maxPendingProcessRecordsInput = 3
-        |         
+        |
         |         # The maximum number of bytes that can be queued
         |         # Default 8388608 (8 * 1024 * 1024 / 8Mb)
         |         maxCacheByteSize = 8388608
-        |         
+        |
         |         # The maximum number of records that can be queued
         |         # Default: 30000
         |         maxRecordsCount = 30000
-        |         
+        |
         |         # The amount of time to wait between calls to Kinesis
         |         # Default: 1500
         |         idleMillisBetweenCalls = 1500
-        |         
+        |
         |         #
         |         # End of Pre-fetching config
         |         #
@@ -231,8 +217,10 @@ class ConsumerConfSpec
         |         # True if we should ignore child shards which have open parents
         |         # Default: not set
         |         ignoreUnexpectedChildShards = false
-        |      }
         |
+        |         # One of PROVISIONED or PAY_PER_REQUEST
+        |         billingMode = PROVISIONED
+        |      }
         |   }
         |}
       """.stripMargin

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerProcessingManagerSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerProcessingManagerSpec.scala
@@ -16,14 +16,9 @@
 
 package com.weightwatchers.reactive.kinesis.consumer
 
-import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets
-import java.util.Date
-
-import scala.jdk.CollectionConverters._
-import akka.actor.{ActorRef, ActorSystem}
+import akka.actor.ActorRef
+import akka.testkit.{TestActor, TestDuration, TestProbe}
 import akka.testkit.TestActor.AutoPilot
-import akka.testkit.{ImplicitSender, TestActor, TestDuration, TestKit, TestProbe}
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker
 import com.amazonaws.services.kinesis.clientlibrary.types.{
@@ -37,35 +32,25 @@ import com.weightwatchers.reactive.kinesis.consumer.ConsumerWorker.{
   ProcessingComplete
 }
 import com.weightwatchers.reactive.kinesis.models.{CompoundSequenceNumber, ConsumerEvent}
+import com.weightwatchers.reactive.kinesis.{AkkaTest, UnitTest}
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.util.Date
 import org.joda.time.{DateTime, DateTimeZone}
 import org.mockito.Mockito
-import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{BeforeAndAfterAll, FreeSpecLike, Matchers}
-import org.scalatestplus.mockito.MockitoSugar
-
+import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.{DurationDouble, FiniteDuration}
-import scala.concurrent.{Await, Future, Promise}
+import scala.concurrent.{Future, Promise}
+import scala.jdk.CollectionConverters._
 
-class ConsumerProcessingManagerSpec
-    extends TestKit(ActorSystem("checkpoint-worker-spec"))
-    with ImplicitSender
-    with FreeSpecLike
-    with Matchers
-    with MockitoSugar
-    with BeforeAndAfterAll
-    with ScalaFutures {
+class ConsumerProcessingManagerSpec extends UnitTest with AkkaTest {
 
   val batchTimeout: FiniteDuration = 2.seconds.dilated
 
   implicit val defaultPatience =
     PatienceConfig(timeout = Span(3, Seconds), interval = Span(50, Millis)) // scalastyle:off
-
-  override def afterAll(): Unit = {
-    system.terminate()
-    Await.result(system.whenTerminated, 5.seconds)
-  }
 
   "The ConsumerProcessingManager" - {
     "Should set the shardId on init" in {
@@ -118,12 +103,12 @@ class ConsumerProcessingManagerSpec
 
         //validate the probe received the Seq of ConsumerEvents
         val expectedMsg = ProcessEvents(
-          Seq(toConsumerEvent(record1),
-              toConsumerEvent(record2),
-              toConsumerEvent(record3),
-              toConsumerEvent(record4),
-              toConsumerEvent(record5),
-              toConsumerEvent(record6)),
+          ArrayBuffer(toConsumerEvent(record1),
+                      toConsumerEvent(record2),
+                      toConsumerEvent(record3),
+                      toConsumerEvent(record4),
+                      toConsumerEvent(record5),
+                      toConsumerEvent(record6)),
           checkpointer,
           shardId
         )

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerProcessingManagerSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerProcessingManagerSpec.scala
@@ -103,12 +103,12 @@ class ConsumerProcessingManagerSpec extends UnitTest with AkkaTest {
 
         //validate the probe received the Seq of ConsumerEvents
         val expectedMsg = ProcessEvents(
-          ArrayBuffer(toConsumerEvent(record1),
-                      toConsumerEvent(record2),
-                      toConsumerEvent(record3),
-                      toConsumerEvent(record4),
-                      toConsumerEvent(record5),
-                      toConsumerEvent(record6)),
+          Seq(toConsumerEvent(record1),
+              toConsumerEvent(record2),
+              toConsumerEvent(record3),
+              toConsumerEvent(record4),
+              toConsumerEvent(record5),
+              toConsumerEvent(record6)),
           checkpointer,
           shardId
         )

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorkerSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorkerSpec.scala
@@ -16,12 +16,11 @@
 
 package com.weightwatchers.reactive.kinesis.consumer
 
-import java.nio.ByteBuffer
-
 import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.testkit.TestActor.AutoPilot
 import akka.testkit.{ImplicitSender, TestActor, TestDuration, TestKit, TestProbe}
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.IRecordProcessorCheckpointer
+import com.weightwatchers.reactive.kinesis.{AkkaTest, UnitTest}
 import com.weightwatchers.reactive.kinesis.consumer.CheckpointWorker.{
   Checkpoint,
   CheckpointResult,
@@ -30,26 +29,12 @@ import com.weightwatchers.reactive.kinesis.consumer.CheckpointWorker.{
 }
 import com.weightwatchers.reactive.kinesis.consumer.ConsumerWorker._
 import com.weightwatchers.reactive.kinesis.models.{CompoundSequenceNumber, ConsumerEvent}
+import java.nio.ByteBuffer
 import org.joda.time.DateTime
-import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, FreeSpecLike, GivenWhenThen, Matchers}
-
 import scala.concurrent.Await
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
-class ConsumerWorkerSpec
-    extends TestKit(ActorSystem("consumer-worker-spec"))
-    with ImplicitSender
-    with FreeSpecLike
-    with Matchers
-    with MockitoSugar
-    with BeforeAndAfterAll
-    with GivenWhenThen {
-
-  override def afterAll(): Unit = {
-    system.terminate()
-    Await.result(system.whenTerminated, 5.seconds)
-  }
+class ConsumerWorkerSpec extends UnitTest with AkkaTest {
 
   "The ConsumerWorker" - {
 

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/KinesisConsumerSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/consumer/KinesisConsumerSpec.scala
@@ -16,11 +16,7 @@
 
 package com.weightwatchers.reactive.kinesis.consumer
 
-import java.io.File
-import java.util
-
-import akka.actor.ActorSystem
-import akka.testkit.{ImplicitSender, TestKit, TestProbe}
+import akka.testkit.TestProbe
 import akka.util.Timeout
 import com.amazonaws.auth.{
   AWSCredentialsProviderChain,
@@ -30,26 +26,17 @@ import com.amazonaws.auth.{
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker
 import com.typesafe.config.ConfigFactory
 import com.weightwatchers.reactive.kinesis.consumer.KinesisConsumer.ConsumerConf
+import com.weightwatchers.reactive.kinesis.{AkkaTest, UnitTest}
+import java.io.File
+import java.util
 import org.mockito.Mockito
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.scalatest._
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.time.{Millis, Seconds, Span}
-
 import scala.concurrent.duration.DurationInt
 
 //scalastyle:off magic.number
-class KinesisConsumerSpec
-    extends TestKit(ActorSystem("consumer-spec"))
-    with ImplicitSender
-    with FreeSpecLike
-    with Matchers
-    with MockitoSugar
-    with BeforeAndAfterAll
-    with GivenWhenThen
-    with ScalaFutures {
+class KinesisConsumerSpec extends UnitTest with AkkaTest {
 
   val defaultKinesisConfig =
     ConfigFactory.parseFile(new File("src/main/resources/reference.conf")).getConfig("kinesis")

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/models/ConsumerEventSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/models/ConsumerEventSpec.scala
@@ -16,15 +16,14 @@
 
 package com.weightwatchers.reactive.kinesis.models
 
+import com.weightwatchers.reactive.kinesis.UnitTest
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.UTF_8
-
 import org.joda.time.DateTime
 import org.scalacheck.Gen
-import org.scalatest.{FreeSpec, Matchers}
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class ConsumerEventSpec extends FreeSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+class ConsumerEventSpec extends UnitTest with ScalaCheckDrivenPropertyChecks {
 
   "A ConsumerEvent" - {
     "can be read as string" in {

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/producer/KinesisProducerActorSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/producer/KinesisProducerActorSpec.scala
@@ -16,36 +16,23 @@
 
 package com.weightwatchers.reactive.kinesis.producer
 
-import akka.actor.{ActorSystem, PoisonPill}
-import akka.testkit.{ImplicitSender, TestActorRef, TestKit, TestProbe}
+import akka.actor.PoisonPill
+import akka.testkit.{TestActorRef, TestProbe}
 import akka.util.Timeout
 import com.amazonaws.services.kinesis.producer.{UserRecordFailedException, UserRecordResult}
 import com.weightwatchers.reactive.kinesis.models.ProducerEvent
 import com.weightwatchers.reactive.kinesis.producer.KinesisProducerActor._
+import com.weightwatchers.reactive.kinesis.{AkkaTest, UnitTest}
 import org.mockito.Mockito._
-import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, FreeSpecLike, Matchers}
-
+import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
 
 //scalastyle:off magic.number
-class KinesisProducerActorSpec
-    extends TestKit(ActorSystem("producer-spec"))
-    with ImplicitSender
-    with FreeSpecLike
-    with Matchers
-    with MockitoSugar
-    with BeforeAndAfterAll {
+class KinesisProducerActorSpec extends UnitTest with AkkaTest {
 
   implicit val timeout = Timeout(5.seconds)
 
   import system.dispatcher
-
-  override def afterAll(): Unit = {
-    system.terminate()
-    Await.result(system.whenTerminated, timeout.duration)
-  }
 
   "The KinesisProducerActor" - {
 

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/producer/KinesisProducerSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/producer/KinesisProducerSpec.scala
@@ -16,24 +16,21 @@
 
 package com.weightwatchers.reactive.kinesis.producer
 
-import java.io.File
-
 import com.amazonaws.services.kinesis.producer.{
   UserRecordResult,
   KinesisProducer => AWSKinesisProducer
 }
 import com.google.common.util.concurrent.SettableFuture
 import com.typesafe.config.ConfigFactory
+import com.weightwatchers.reactive.kinesis.UnitTest
 import com.weightwatchers.reactive.kinesis.models.ProducerEvent
+import java.io.File
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
-
 import scala.concurrent.Future
 
 //scalastyle:off magic.number
-class KinesisProducerSpec extends FreeSpec with Matchers with MockitoSugar with BeforeAndAfterAll {
+class KinesisProducerSpec extends UnitTest {
 
   implicit val ece = scala.concurrent.ExecutionContext.global
 

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/producer/ProducerConfSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/producer/ProducerConfSpec.scala
@@ -16,38 +16,24 @@
 
 package com.weightwatchers.reactive.kinesis.producer
 
-import java.io.File
-
-import akka.actor.ActorSystem
-import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
-import com.amazonaws.auth.ContainerCredentialsProvider.ECSCredentialsEndpointProvider
 import com.amazonaws.auth.{
-  DefaultAWSCredentialsProviderChain,
   EC2ContainerCredentialsProviderWrapper,
   EnvironmentVariableCredentialsProvider
 }
-import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.regions.Regions
 import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration
 import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration.ThreadingModel
 import com.amazonaws.services.kinesis.producer.protobuf.Config.AdditionalDimension
 import com.typesafe.config.ConfigFactory
-import org.apache.http.client.CredentialsProvider
-import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, FreeSpecLike, Matchers}
-
+import com.weightwatchers.reactive.kinesis.{AkkaTest, UnitTest}
+import java.io.File
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Random
 
 //scalastyle:off magic.number
-class ProducerConfSpec
-    extends TestKit(ActorSystem("producer-spec"))
-    with ImplicitSender
-    with FreeSpecLike
-    with Matchers
-    with MockitoSugar
-    with BeforeAndAfterAll {
+class ProducerConfSpec extends UnitTest with AkkaTest {
 
   val defaultKinesisConfig =
     ConfigFactory.parseFile(new File("src/main/resources/reference.conf")).getConfig("kinesis")
@@ -214,11 +200,6 @@ class ProducerConfSpec
     .withFallback(defaultKinesisConfig)
 
   implicit val timeout = Timeout(5.seconds)
-
-  override def afterAll(): Unit = {
-    system.terminate()
-    Await.result(system.whenTerminated, timeout.duration)
-  }
 
   "The ProducerConf" - {
 

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSinkGraphStageSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/stream/KinesisSinkGraphStageSpec.scala
@@ -16,13 +16,10 @@
 
 package com.weightwatchers.reactive.kinesis.stream
 
-import java.util.Collections
-
 import akka.Done
-import akka.actor.{Actor, ActorRef, ActorSystem, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import akka.stream.scaladsl.{Sink, Source}
-import akka.stream.{ActorMaterializer, Materializer}
-import akka.testkit.{TestActorRef, TestKit}
+import akka.testkit.TestActorRef
 import com.amazonaws.services.kinesis.producer.UserRecordResult
 import com.weightwatchers.reactive.kinesis.models.ProducerEvent
 import com.weightwatchers.reactive.kinesis.producer.KinesisProducerActor.{
@@ -30,24 +27,16 @@ import com.weightwatchers.reactive.kinesis.producer.KinesisProducerActor.{
   SendSuccessful,
   SendWithCallback
 }
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.{BeforeAndAfterAll, FreeSpecLike, Matchers}
-
+import com.weightwatchers.reactive.kinesis.{AkkaTest, UnitTest}
+import java.util.Collections
 import scala.collection.mutable
+import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
 
-class KinesisSinkGraphStageSpec
-    extends TestKit(ActorSystem("source-graph-spec"))
-    with FreeSpecLike
-    with Matchers
-    with BeforeAndAfterAll
-    with ScalaFutures
-    with Eventually {
+class KinesisSinkGraphStageSpec extends UnitTest with AkkaTest {
 
-  implicit val materializer: Materializer = ActorMaterializer()
-  implicit val ec                         = system.dispatcher
-  implicit val defaultPatience            = PatienceConfig(5.seconds, interval = 50.millis)
+  implicit val ec              = system.dispatcher
+  implicit val defaultPatience = PatienceConfig(5.seconds, interval = 50.millis)
 
   "KinesisSinkGraph" - {
 
@@ -136,10 +125,5 @@ class KinesisSinkGraphStageSpec
     val testActor = TestActorRef[TestProducerActor](Props(new TestProducerActor(sendFn)))
     val sink      = Kinesis.sink(Props(new ForwardToProducerActor(testActor)), maxOutstanding)
     sinkFn(sink, testActor)
-  }
-
-  override def afterAll(): Unit = {
-    system.terminate()
-    Await.result(system.whenTerminated, 5.seconds)
   }
 }

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/utils/ScalaListenableFutureSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/utils/ScalaListenableFutureSpec.scala
@@ -17,18 +17,13 @@
 package com.weightwatchers.reactive.kinesis.utils
 
 import com.google.common.util.concurrent.SettableFuture
+import com.weightwatchers.reactive.kinesis.UnitTest
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
 
 /**
   * Tests the implicit future conversions.
   */
-class ScalaListenableFutureSpec
-    extends FreeSpec
-    with Matchers
-    with MockitoSugar
-    with BeforeAndAfterAll {
+class ScalaListenableFutureSpec extends UnitTest {
 
   implicit val ece = scala.concurrent.ExecutionContext.global
 

--- a/src/test/scala/com/weightwatchers/reactive/kinesis/utils/TypesafeConfigExtensionsSpec.scala
+++ b/src/test/scala/com/weightwatchers/reactive/kinesis/utils/TypesafeConfigExtensionsSpec.scala
@@ -17,17 +17,12 @@
 package com.weightwatchers.reactive.kinesis.utils
 
 import com.typesafe.config.ConfigFactory
-import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+import com.weightwatchers.reactive.kinesis.UnitTest
 
 /**
   * Tests the implicit future conversions.
   */
-class TypesafeConfigExtensionsSpec
-    extends FreeSpec
-    with Matchers
-    with MockitoSugar
-    with BeforeAndAfterAll {
+class TypesafeConfigExtensionsSpec extends UnitTest {
 
   val kplConfig = ConfigFactory.parseString("""
       |kpl {


### PR DESCRIPTION
- bump to akka 2.6
- clean test base by introducing traits for Unit and Integration tests
- bump scalatest which introduces additional separate dependencies
- introduce base traits for all tests

Note: this is using the original travis setup which is not working.
The tests and integration tests are running green locally.