### PR TITLE
[Fix] Use builder for sorted set.

### DIFF
--- a/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorker.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorker.scala
@@ -226,6 +226,7 @@ private[consumer] class ConsumerWorker(eventProcessor: ActorRef,
                                     None) {
 
     private val batchSequenceNumbers: collection.mutable.SortedSet[CompoundSequenceNumber] = {
+      // Use builder here, since this is the common denominator for scala 2.12 (apply) and 2.13 (from)
       val builder = collection.mutable.SortedSet
         .newBuilder[CompoundSequenceNumber](CompoundSequenceNumber.orderingBySeqAndSubSeq.reverse)
       expectedResponses.foreach(elem => builder += elem.sequenceNumber)

--- a/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorker.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorker.scala
@@ -225,10 +225,12 @@ private[consumer] class ConsumerWorker(eventProcessor: ActorRef,
                                   previouslyReceivedHighestSeq: Option[CompoundSequenceNumber] =
                                     None) {
 
-    private val batchSequenceNumbers: collection.mutable.SortedSet[CompoundSequenceNumber] =
-      collection.mutable.SortedSet.from(expectedResponses.map(_.sequenceNumber))(
-        CompoundSequenceNumber.orderingBySeqAndSubSeq.reverse
-      )
+    private val batchSequenceNumbers: collection.mutable.SortedSet[CompoundSequenceNumber] = {
+      val builder = collection.mutable.SortedSet
+        .newBuilder[CompoundSequenceNumber](CompoundSequenceNumber.orderingBySeqAndSubSeq.reverse)
+      expectedResponses.foreach(elem => builder += elem.sequenceNumber)
+      builder.result()
+    }
 
     private val receivedResponseSeqNos: collection.mutable.SortedSet[CompoundSequenceNumber] =
       collection.mutable.SortedSet


### PR DESCRIPTION
scala 2.12 uses SortedSet.apply which is not applicable in 2.13
scala 2.13 introduces SortedSet.from which is not applicable in 2.12
Rewrite the logic with the help of builder which is available in 2.12 and 2.13.