### PR TITLE
Reduce level of skipped checkpointing

### DIFF
--- a/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorker.scala
+++ b/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorker.scala
@@ -483,7 +483,7 @@ private[consumer] class ConsumerWorker(eventProcessor: ActorRef,
               finaliseShutdown(outerSender, false)
           }
         case None =>
-          logger.warn(s"Worker for shard $latestShardId: Skipped checkpointing on shutdown")
+          logger.info(s"Worker for shard $latestShardId: Skipped checkpointing on shutdown")
           finaliseShutdown(outerSender, false)
       }
 


### PR DESCRIPTION
During shutdown, we get log messages like this:

```
trip-booking2-5d48ddb4f8-vh7pl trip-booking2 2020-02-13T14:46:12,276 WARN  com.weightwatchers.reactive.kinesis.consumer.ConsumerWorker:trip-booking-kinesis.akka.default-dispatcher-23::::::: Worker for shard None: Skipped checkpointing on shutdown 
```

As the docs for the `checkpoint` method says (https://github.com/moia-dev/reactive-kinesis/blob/f83ae55be49409f6d4902730cedd0a305a580bd9/src/main/scala/com/weightwatchers/reactive/kinesis/consumer/ConsumerWorker.scala#L517), a skipped checkpoint is
not indicating a possible problem, therefore the log level should not be WARN.

This pr changes it to INFO